### PR TITLE
fix: Fix inconsistent background color between scaffold and canvas

### DIFF
--- a/lib/src/storybook/storybook_wrappers.dart
+++ b/lib/src/storybook/storybook_wrappers.dart
@@ -51,9 +51,11 @@ Widget materialWrapper(BuildContext context, Widget? child) {
   final LocalizationData localization = context.watch<LocalizationNotifier>().value;
   return MaterialApp(
     theme: ThemeData.light().copyWith(
+      canvasColor: Colors.white,
       scaffoldBackgroundColor: Colors.white,
     ),
     darkTheme: ThemeData.dark().copyWith(
+      canvasColor: Colors.black,
       scaffoldBackgroundColor: Colors.black,
     ),
     debugShowCheckedModeBanner: false,


### PR DESCRIPTION
Fix background color inconsistency between canvas and scaffold background color. Below is an example of the issue before the fix, with the background of the first widget in the original canvas color instead of the same as the scaffold around it:

<img width="1266" height="924" alt="image" src="https://github.com/user-attachments/assets/3949dd27-6809-4f61-b85a-babf8c8e55d6" />


